### PR TITLE
Dockerfile multi stage 개선

### DIFF
--- a/build/ai-gateway/Dockerfile
+++ b/build/ai-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -7,9 +7,8 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 RUN go build -ldflags="-s -w" -o ai-gateway ./cmd/ai-gateway
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /app/ai-gateway /app/
 
 ENTRYPOINT ["/app/ai-gateway"]

--- a/build/channel-config/Dockerfile
+++ b/build/channel-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -7,7 +7,7 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 RUN go build -ldflags="-s -w" -o channel-config ./cmd/channel-config
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /app/channel-config /app/
 

--- a/build/daily-scrum/Dockerfile
+++ b/build/daily-scrum/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -7,9 +7,8 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 RUN go build -ldflags="-s -w" -o daily-scrum ./cmd/daily-scrum
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/daily-scrum /app/
 
 ENTRYPOINT ["/app/daily-scrum"]

--- a/build/data-portal/Dockerfile
+++ b/build/data-portal/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -7,9 +7,8 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 RUN go build -ldflags="-s -w" -o data-portal ./cmd/data-portal
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/data-portal /app/
 
 ENTRYPOINT ["/app/data-portal"]

--- a/build/jarvis/Dockerfile
+++ b/build/jarvis/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -7,9 +7,8 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 RUN go build -ldflags="-s -w" -o jarvis ./cmd/jarvis
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/jarvis /app/
 
 ENTRYPOINT ["/app/jarvis"]

--- a/build/weekly-report/Dockerfile
+++ b/build/weekly-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY . .
@@ -7,9 +7,8 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 RUN go build -ldflags="-s -w" -o weekly-report ./cmd/weekly-report
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/weekly-report /app/
 
 ENTRYPOINT ["/app/weekly-report"]


### PR DESCRIPTION
빌드에 사용하는 golang 이미지를 크기가 더 작은 alpine으로 변경.

실행 이미지를 scratch에서 ssl 인증서 및 런타임 환경에서 필요한
파일이 최소한으로 포함되어 있는 distroless로 변경.
